### PR TITLE
Update p2-9-tuple-set-dict.ipynb

### DIFF
--- a/p2-9-tuple-set-dict.ipynb
+++ b/p2-9-tuple-set-dict.ipynb
@@ -1052,7 +1052,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "另外，因为 ***dict* 的 *key* 必须是 *immutable***，所以 *tuple* 可用作 *dict* 中的 *key*，而 *list* 不可以。\n",
+    "另外，因为 ***dict* 的 *key* 必须是 *immutable***，所以 *tuple* 可用作 *dict* 中的 *key*，而 *list* 不可以。 \n",
     "\n",
     "举个例子。假定我们想统计学生们参加体育活动的次数，我们可以用 `(学生名，体育项目)` 作 key，而对应的参加次数作为 value，那么这个 *dict* 大致就是这样的：\n",
     "\n",


### PR DESCRIPTION
>因为 ***dict* 的 *key* 必须是 *immutable***，所以 *tuple* 可用作 *dict* 中的 *key*，而 *list* 不可以。

 这一句实际看到的效果不理想，但在提问这里看到的又是正常的。我不知道怎么改了，老师可以看一下，下面照片是实际看到的效果，难道是我电脑的原因才会这样。

---
<img width="732" alt="Screenshot 2023-08-14 at 11 27 28 AM" src="https://github.com/neolee/wop/assets/57254889/6467dea0-8c1c-41f4-abb4-552748639f4b">
